### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/html/lib/bootstrap/js/bootstrap.js
+++ b/html/lib/bootstrap/js/bootstrap.js
@@ -123,8 +123,8 @@ var Util = function ($$$1) {
   function escapeId(selector) {
     // We escape IDs in case of special selectors (selector = '#myId:something')
     // $.escapeSelector does not exist in jQuery < 3
-    selector = typeof $$$1.escapeSelector === 'function' ? $$$1.escapeSelector(selector).substr(1) : selector.replace(/(:|\.|\[|\]|,|=|@)/g, '\\$1');
-    return selector;
+    selector = typeof $$$1.escapeSelector === 'function' ? $$$1.escapeSelector(selector).substr(1) : selector.replace(/([:\\.\\[\\]\\,\\=\\@\\])/g, '\\$1');
+    return selector.replace(/\\/g, '\\\\');
   }
   /**
    * --------------------------------------------------------------------------


### PR DESCRIPTION
Potential fix for [https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/9](https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/9)

To fix the problem, we need to ensure that all occurrences of special characters, including backslashes, are properly escaped in the `selector` string. This can be achieved by using a regular expression with the global flag to replace all occurrences of the special characters, including backslashes. We should also escape the backslash itself to prevent it from being used to escape other characters.