### PR TITLE
Potential fix for code scanning alert no. 59: Unsafe jQuery plugin

### DIFF
--- a/html/lib/bootstrap/js/bootstrap.js
+++ b/html/lib/bootstrap/js/bootstrap.js
@@ -3447,7 +3447,7 @@ var ScrollSpy = function ($$$1) {
 
         config.target = "#" + id;
       } else {
-        config.target = $$$1.find(config.target);
+        config.target = $$$1.find(config.target).selector;
       }
 
       Util.typeCheckConfig(NAME, config, DefaultType);


### PR DESCRIPTION
Potential fix for [https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/59](https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/59)

To fix the problem, we need to ensure that the `config.target` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method, which interprets the input as a CSS selector. We will modify the `_getConfig` method to use `jQuery.find` for the `config.target` parameter when it is a string. This change will prevent the possibility of XSS by ensuring that the input is not interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
