### PR TITLE
Potential fix for code scanning alert no. 58: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/html/lib/jquery/js/jquery.js
+++ b/html/lib/jquery/js/jquery.js
@@ -5312,7 +5312,7 @@ jQuery.fn.extend({
 			if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&
 				!wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) {
 
-				value = DOMPurify.sanitize(value).replace( rxhtmlTag, "<$1></$2>" );
+				value = DOMPurify.sanitize(value);
 
 				try {
 					for ( ; i < l; i++ ) {


### PR DESCRIPTION
Potential fix for [https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/58](https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/58)

To fix the problem, we should avoid modifying the sanitized HTML string by expanding self-closing tags. Instead, we can rely on the sanitization library to handle the HTML safely. We will remove the transformation that expands self-closing tags and directly use the sanitized HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
