### PR TITLE
Potential fix for code scanning alert no. 34: DOM text reinterpreted as HTML

### DIFF
--- a/html/lib/bootstrap/js/bootstrap.bundle.js
+++ b/html/lib/bootstrap/js/bootstrap.bundle.js
@@ -6,10 +6,11 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('jquery')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'jquery'], factory) :
-	(factory((global.bootstrap = {}),global.jQuery));
-}(this, (function (exports,$) { 'use strict';
+	(factory((global.bootstrap = {}),global.jQuery,global.DOMPurify));
+}(this, (function (exports,$,DOMPurify) { 'use strict';
 
 $ = $ && $.hasOwnProperty('default') ? $['default'] : $;
+DOMPurify = DOMPurify && DOMPurify.hasOwnProperty('default') ? DOMPurify['default'] : DOMPurify;
 
 function _defineProperties(target, props) {
   for (var i = 0; i < props.length; i++) {
@@ -155,6 +156,7 @@ var Util = function ($$$1) {
       }
 
       try {
+        selector = DOMPurify.sanitize(selector);
         var $selector = $$$1(document).find(selector);
         return $selector.length > 0 ? selector : null;
       } catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/34](https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/34)

To fix the problem, we need to ensure that the `selector` is properly sanitized before it is used in the jQuery selector. One way to do this is to use a function that escapes any potentially dangerous characters in the `selector`. We can use a well-known library like `DOMPurify` to sanitize the `selector` before using it.

1. Import the `DOMPurify` library.
2. Use `DOMPurify.sanitize` to sanitize the `selector` before using it in the jQuery selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
