### PR TITLE
Revert "Bump express from 4.21.2 to 5.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "conceal-api": "^0.8.6",
     "download-github-release": "^0.3.2",
     "execa": "^9.2.0",
-    "express": "^5.1.0",
+    "express": "^4.18.1",
     "express-rate-limit": "^7.1.5",
     "extract-zip": "^2.0.1",
     "geoip2-api": "^1.0.2",


### PR DESCRIPTION
Reverts ConcealNetwork/conceal-guardian#56