### PR TITLE
Potential fix for code scanning alert no. 13: Unsafe jQuery plugin

### DIFF
--- a/html/lib/bootstrap/js/bootstrap.bundle.js
+++ b/html/lib/bootstrap/js/bootstrap.bundle.js
@@ -5830,7 +5830,7 @@ var ScrollSpy = function ($$$1) {
         var targetSelector = Util.getSelectorFromElement(element);
 
         if (targetSelector) {
-          target = $$$1(targetSelector)[0];
+          target = $$$1.find(targetSelector)[0];
         }
 
         if (target) {
@@ -5872,7 +5872,7 @@ var ScrollSpy = function ($$$1) {
       config = _extends({}, Default, config);
 
       if (typeof config.target !== 'string') {
-        var id = $$$1(config.target).attr('id');
+        var id = $$$1.find(config.target).attr('id');
 
         if (!id) {
           id = Util.getUID(NAME);


### PR DESCRIPTION
Potential fix for [https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/13](https://github.com/ConcealNetwork/conceal-guardian/security/code-scanning/13)

To fix the problem, we need to ensure that the `config.target` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly using `jQuery(config.target)`. This change will prevent the interpretation of `config.target` as HTML, mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
